### PR TITLE
Fixes RT#90966 Class::MOP::load_class deprecation warnings

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,6 +12,7 @@ requires q(NetAddr::IP) => 4.0;
 requires q(Path::Class) => 0.19;
 requires q(POE::Filter::DHCPd::Lease) => 0.04;
 requires q(Time::HiRes) => 1.90;
+requires q(Class::Load) => 0.20;
 
 test_requires q(Benchmark) => 1.0;
 test_requires q(Test::More) => 0.90;

--- a/lib/Net/ISC/DHCPd.pm
+++ b/lib/Net/ISC/DHCPd.pm
@@ -35,6 +35,7 @@ L<the man pages|http://www.google.com/search?q=man+dhcpd>.
 
 =cut
 
+use Class::Load;
 use Moose;
 use Moose::Util::TypeConstraints;
 use MooseX::Types::Path::Class qw(File);
@@ -201,7 +202,7 @@ sub _build_child_obj {
     my $type = shift;
     my $self = shift;
 
-    Class::MOP::load_class("Net::ISC::DHCPd::$type");
+    Class::Load::load_class("Net::ISC::DHCPd::$type");
 
     return "Net::ISC::DHCPd::$type"->new(@_);
 }

--- a/lib/Net/ISC/DHCPd/Config/Role.pm
+++ b/lib/Net/ISC/DHCPd/Config/Role.pm
@@ -18,6 +18,7 @@ This can be turned off by adding the line below before calling L</parse>.
 
 =cut
 
+use Class::Load;
 use Moose::Role;
 
 requires 'generate';
@@ -377,7 +378,7 @@ sub create_children {
         my $name = lc +($class =~ /::(\w+)$/)[0];
         my $attr = $name .'s';
 
-        Class::MOP::load_class($class);
+        Class::Load::load_class($class);
 
         unless($meta->find_method_by_name($attr)) {
             $meta->add_method("add_${name}" => sub { shift->_add_child($class, @_) });


### PR DESCRIPTION
This fixes RT#90966: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90966
