### PR TITLE
added Authoritative class to subnet class and parse trailing comments

### DIFF
--- a/lib/Net/ISC/DHCPd/Config/Role.pm
+++ b/lib/Net/ISC/DHCPd/Config/Role.pm
@@ -285,6 +285,12 @@ sub parse {
                 push @comments, $1;
                 next LINE;
             }
+            # lines with statements and comment, reprocess the statement and add the comment to comments array
+            if($line =~ /^(.*)\s*\#\s*(.*)/) {
+                push @comments, $2;
+                push @{$linebuf}, $1;
+                next LINE;
+            }
 
             # after semicolon or braces if there isn't a semicolon or return insert a newline
             if ($line =~ s/([;\{\}])([^;\n\r])/$1\n$2/g) {

--- a/lib/Net/ISC/DHCPd/Config/Subnet.pm
+++ b/lib/Net/ISC/DHCPd/Config/Subnet.pm
@@ -47,6 +47,7 @@ sub children {
         Net::ISC::DHCPd::Config::Class
         Net::ISC::DHCPd::Config::KeyValue
         Net::ISC::DHCPd::Config::Block
+        Net::ISC::DHCPd::Config::Authoritative
     /;
 }
 __PACKAGE__->create_children(__PACKAGE__->children());


### PR DESCRIPTION
Allow "authoritative" statement to be placed within subnet declarations
and enhanced comment parsing.
The comment parsing is actual quick and dirty to prevent parse errors and needs more improvements since not each comment above a statement belongs to it. Also trailing comments inside expressions are merged into one block and the association to specific expression is lost.