### PR TITLE
add vendor-class-identifier, cltt, and uid parsing for leases

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Net-ISC-DHCPd
 
+0.1710   ?
+       - add vendor-class-identifier, cltt, and uid parsing for leases
+
 0.1709   Wed Feb  3 18:47:29 UTC 2016
        - shared-network with periods now parses correctly
 

--- a/lib/Net/ISC/DHCPd.pm
+++ b/lib/Net/ISC/DHCPd.pm
@@ -6,7 +6,7 @@ Net::ISC::DHCPd - Interacts with ISC DHCPd
 
 =head1 VERSION
 
-0.1709
+0.1710
 
 =head1 SYNOPSIS
 
@@ -43,7 +43,7 @@ use Net::ISC::DHCPd::Types ':all';
 use File::Temp 0.20;
 use v5.10.1;
 
-our $VERSION = eval '0.1709';
+our $VERSION = eval '0.1710';
 
 =head1 ATTRIBUTES
 

--- a/lib/Net/ISC/DHCPd/Leases.pm
+++ b/lib/Net/ISC/DHCPd/Leases.pm
@@ -109,11 +109,14 @@ our $START   = qr#^ lease \s ([\d\.]+) \s \{ #mxo;
 our $END     = qr# } [\n\r]+ #mxo;
 our $PARSER  = qr / (?| (starts) \s\d+\s (.+?)
                     | (ends)    \s\d+\s (.+?)
+                    | (cltt)    \s\d+\s (.+?)
                     | ^\s*binding \s (state) \s (\S+)
                     | ^\s*(next) \s binding \s state \s (\S+)
                     | hardware \s (ethernet) \s (\S+)
                     | option \s agent.(remote-id) \s (.+?)
                     | option \s agent.(circuit-id) \s (.+?)
+                    | (uid) \s \"([^"]+)\"
+                    | set \s (vendor-class-identifier) \s \= \s \"([^"]+)\"
                     | client-(hostname) \s "([^"]+)"
                     ) /mxo;
 
@@ -140,6 +143,7 @@ sub _done {
         ip           => 'ip_address',
         hostname     => 'client_hostname',
         ethernet     => 'hardware_address',
+        'vendor-class-identifier' => 'vendor_class_identifier',
     );
 
     for my $key (keys %map) {

--- a/lib/Net/ISC/DHCPd/Leases.pm
+++ b/lib/Net/ISC/DHCPd/Leases.pm
@@ -124,7 +124,7 @@ our $PARSER  = qr / (?| (starts) \s\d+\s (.+?)
 sub _done {
     my ($self, $lease) = @_;
 
-    for my $k (qw/starts ends/) {
+    for my $k (qw/starts ends cltt/) {
         next unless($lease->{$k});
         if(my @values = $lease->{$k} =~ $DATE) {
             $values[1]--; # decrease month

--- a/lib/Net/ISC/DHCPd/Role/Lease.pm
+++ b/lib/Net/ISC/DHCPd/Role/Lease.pm
@@ -329,6 +329,38 @@ omapi_attr hardware_type => (
     actions => [qw/examine modify/],
 );
 
+=head2 uid
+
+ $int = $self->uid;
+ $self->uid($int);
+
+The UID for the client that made the transaction.
+
+Actions: examine.
+
+=cut
+
+omapi_attr uid => (
+    isa => 'Any',
+    actions => [qw/examine/],
+);
+
+=head2 vendor_class_identifier
+
+ $int = $self->uid;
+ $self->uid($int);
+
+The vendor class identifier for the client that made the transaction.
+
+Actions: examine.
+
+=cut
+
+omapi_attr vendor_class_identifier => (
+    isa => 'Any',
+    actions => [qw/examine/],
+);
+
 =head1 ACKNOWLEDGEMENTS
 
 Most of the documentation is taken from C<dhcpd(8)>.


### PR DESCRIPTION
Adds in the ability to parse cltt, uid, and vendor-class-identifier from the leases file.